### PR TITLE
add python packaging and testing pedagogy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,3 +34,6 @@
 [submodule "2018-02-16-rstudioconf2018-recap"]
 	path = 2018-02-16-rstudioconf2018-recap
 	url = git@github.com:ClaytonJY/rstudioconf-2018-recaps.git
+[submodule "2018-02-22-python-packaging-testing"]
+	path = 2018-02-22-python-packaging-testing
+	url = https://github.com/scheidec/testing-in-python

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ A collection of our weekly, internal presentations.
 - 2018-01-25: [CI/CD](https://cdn.rawgit.com/scheidec/ci-cd/1e88a370324388f99415c2a6d0e7040981b743e6/CI-CD/CI-CD.html)
 - 2018-02-01: [Caret](https://cdn.rawgit.com/MBattagl/caret/github-master/caret.html)
 - 2018-02-16: [rstudio::conf 2018 recap](https://cdn.rawgit.com/ClaytonJY/rstudioconf-2018-recaps/b8ea74b148ab9721f6b1c9b06aedbffe8747cce6/methods-consultants/methods-consultants.html)
+- 2018-02-22: [Python Packaging and Unit Testing](https://cdn.rawgit.com/scheidec/testing-in-python/99a53af1ae54adc9fc72309f47799e44730c01aa/index.html)


### PR DESCRIPTION
Closes #10 

The link to the pywallet example package on gitlab is contained in the slides, so I didn't add it anywhere here.